### PR TITLE
Fixes bug with incorrect headings being sent to calibre

### DIFF
--- a/book.js
+++ b/book.js
@@ -46,7 +46,7 @@ export default async function * processBook (calibreLibraryPath, koboVolume, cal
   for (const chapter of chapters) {
     for await (const annotation of processChapter(zip, chapter)) {
       const tree = []
-      let nav = toc[chapter.path]
+      let nav = toc[annotation.toc_entry_path]
 
       while (nav) {
         tree.unshift(nav.title)

--- a/bookmark.js
+++ b/bookmark.js
@@ -247,6 +247,11 @@ function getSpineFromContentId (id) {
   return { index: Number(index), name }
 }
 
+function getTocEntryPathFromContentId (id) {
+  const tocEntryPath = id.split('#(')[1].split(')')[1]
+  return tocEntryPath
+}
+
 export default function processBookmark (document, bookmark) {
   const spine = getSpineFromContentId(bookmark.ContentID)
 
@@ -292,6 +297,7 @@ export default function processBookmark (document, bookmark) {
       type: 'highlight',
       uuid: bookmark.BookmarkID
     },
-    searchable_text: bookmark.Text
+    searchable_text: bookmark.Text,
+    toc_entry_path: getTocEntryPathFromContentId(bookmark.ContentID)
   }
 }

--- a/toc.js
+++ b/toc.js
@@ -7,7 +7,7 @@ function recurseTree (nav, prefix = '', parent = null, tree = {}) {
     }
 
     const title = child.querySelector('navLabel text').textContent
-    const path = child.querySelector('content').getAttribute('src').split('#')[0]
+    const path = child.querySelector('content').getAttribute('src')
 
     tree[`${prefix}${path}`] = {
       title,


### PR DESCRIPTION
Highlights were being sent to calibre with incorrect headings corresponding to their location. This was because the program was constructing an incomplete representation of the table of contents as it wasn't catering for the fact that there can be various headings in each content file.

Fixes https://github.com/valeriangalliat/kobo-highlights-to-calibre/issues/8.